### PR TITLE
Friendly advice about  trim()

### DIFF
--- a/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
+++ b/zipkin-server/src/main/java/zipkin2/server/internal/ZipkinQueryApiV2.java
@@ -151,6 +151,7 @@ public class ZipkinQueryApiV2 {
   @Get("/api/v2/trace/{traceId}")
   @Blocking
   public AggregatedHttpResponse getTrace(@Param("traceId") String traceId) throws IOException {
+    traceId = traceId != null ? traceId.trim() :null;
     traceId = Span.normalizeTraceId(traceId);
     List<Span> trace = storage.traces().getTrace(traceId).execute();
     if (trace.isEmpty()) {


### PR DESCRIPTION
Friendly advice
when use "@get("/api/v2/trace/{traceId}")"
here is the code traceId = Span.normalizeTraceId(traceId);
if trace with space , it will doesnt work.

[ in ZipkinQueryApiV2, we add this “ traceId = traceId != null ? traceId.trim() :null; ” ]

I think it's okay to add trim when querying, this performance is not affected at all.
Maybe this is not the best way to deal with it, you can also improve it according to the friendliness I mentioned in the follow-up, and you do n’t have to use mine completely.
I also mentioned that adding a common to SPAN may cause low performance problems, so set the trim here